### PR TITLE
Incluyo el nombre del dataset en la distribucion

### DIFF
--- a/geoandino/apps/datajsonar/tests/test_data_jsonar.py
+++ b/geoandino/apps/datajsonar/tests/test_data_jsonar.py
@@ -142,7 +142,7 @@ class DataJsonArDistributionMixin:
         expected = {
             "accessURL": get_access_url(resource, link),
             "downloadURL": link.url,
-            "title": link.name,
+            "title": "%s (%s)" % (resource.title, link.name),
             "issued": link.extra_fields.issued,
         }
         for key, value in expected.iteritems():

--- a/geoandino/apps/datajsonar/utils/datajsonar.py
+++ b/geoandino/apps/datajsonar/utils/datajsonar.py
@@ -23,7 +23,7 @@ def distribution_from(resource, link):
     return {
         "accessURL": get_access_url(resource, link),
         "downloadURL": link.url,
-        "title": link.name,
+        "title": "%s (%s)" % (resource.title, link.name),
         "issued": link.extra_fields.issued
     }
 


### PR DESCRIPTION
En la implementacion, paso de:
```
{
accessURL: "http://localhost/layers/geonode:actividades_humanas",
downloadURL: "http://localhost/geoserver/geonode/wfs",
issued: "2017-09-26T08:18:01.645575",
title: "OGC WFS: geonode Service"
},
```
a
```
{
accessURL: "http://localhost/layers/geonode:actividades_humanas",
downloadURL: "http://localhost/geoserver/geonode/wfs",
issued: "2017-09-26T08:18:01.645575",
title: "actividades_humanas (OGC WFS: geonode Service)"
},
```

refs:#36
closes #36